### PR TITLE
changing to axis=1 in _BatchRunner.py

### DIFF
--- a/src/ModularCirc/_BatchRunner.py
+++ b/src/ModularCirc/_BatchRunner.py
@@ -98,7 +98,7 @@ class _BatchRunner:
 
     def run_batch(self, n_jobs=1, **kwargs):
         if n_jobs == 1:
-            success = self._samples.apply(lambda row : self._run_case(row, **kwargs), axis=0)
+            success = self._samples.apply(lambda row : self._run_case(row, **kwargs), axis=1)
         else:
             success = joblib.Parallel(n_jobs=n_jobs)(
                                         joblib.delayed(self._run_case)(row, **kwargs)


### PR DESCRIPTION
As described in the issue, when not paralellising jobs in BatchRunner, the operation is performed column-wise instead of row-wise. Simply changing the axis=0 to axis=1 fixes this. 