### PR TITLE
Add support for multiple Python versions (3.10-3.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   build-conda:
     name: Conda environment
     runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     defaults:
       run:
         shell: bash -el {0}
@@ -36,7 +39,7 @@ jobs:
         with:
           activate-environment: myenv
           environment-file: environment.yml
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
           auto-activate-base: false
 
       - name: Install dependencies
@@ -52,6 +55,9 @@ jobs:
   build-venv:
     name: Python virtual environment
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code
@@ -60,7 +66,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
 
     - name: Set up environment
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,18 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+]
 
 dependencies = [
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ license-files = ["LICEN[CS]E*"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py310,py311,py312,py313
+
+[testenv]
+deps = 
+    matplotlib
+    numba
+    numpy
+    pandas
+    scipy
+    joblib
+    pandera
+    tdqm
+commands = python -m unittest discover -s tests
+
+[testenv:py310]
+basepython = python3.10
+
+[testenv:py311]
+basepython = python3.11
+
+[testenv:py312]
+basepython = python3.12
+
+[testenv:py313]
+basepython = python3.13

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     scipy
     joblib
     pandera
-    tdqm
+    tqdm
 commands = python -m unittest discover -s tests
 
 [testenv:py310]


### PR DESCRIPTION
- Update CI workflows to test Python 3.10, 3.11, 3.12, and 3.13
- Add Python version classifiers to pyproject.toml
- Add tox.ini for local multi-version testing
- This should fix the PyPI platforms badge once published